### PR TITLE
Align Expo Router starter structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ expo-env.d.ts
 
 # Native
 .kotlin/
+/ios
+/android
 *.orig.*
 *.jks
 *.p8
@@ -45,4 +47,5 @@ yarn-error.*
 _vscode/
 
 # example
+example
 app-example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.
 - tRPC v11, TanStack Query, SuperJSON, and Zod wiring.
 - React Native focus and network handling for TanStack Query.
 - Public open-source project docs and GitHub templates.
+- Reset script aligned with the current `create-expo-app` `src/app` structure.
 
 ### Changed
 
 - tRPC client uses relative `/api/trpc` by default for Expo Router API routes.
+- Documented the Expo Router folder layout verified from a fresh Expo project.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then press:
 
 ```bash
 bun run start       # Start Expo
+bun run reset-project # Move starter code aside and create a blank src/app
 bun run ios         # Start Expo and open iOS
 bun run android     # Start Expo and open Android
 bun run web         # Start Expo for web
@@ -61,6 +62,7 @@ src/
   app/
     _layout.tsx              # App providers and navigation shell
     index.tsx                # Example screen
+    api/hello+api.ts         # Minimal Expo API Route example
     api/trpc/[trpc]+api.ts   # Expo API Route for tRPC
   components/
     hello.tsx                # Example tRPC query consumer
@@ -73,7 +75,11 @@ src/
   trpc/
     query-client.ts          # TanStack Query defaults
     react.tsx                # tRPC React provider/client
+scripts/
+  reset-project.js           # Reset to a blank Expo Router src/app
 ```
+
+This follows the current `create-expo-app` convention of using `src/app` for Expo Router. Unlike the default template, this starter keeps `web.output` set to `server` because Expo API Routes need a server bundle.
 
 ## How tRPC Is Wired
 
@@ -132,6 +138,17 @@ Use ngrok, Cloudflare Tunnel, or another tunnel only when:
 For production native builds that call Expo Router API Routes, deploy the server and configure the Expo Router `origin` in `app.json`, or set `EXPO_PUBLIC_API_URL` to your deployed API origin.
 
 ## Adding API Routes
+
+Expo API Routes live in `src/app` and use the `+api.ts` file suffix.
+
+A minimal route looks like this:
+
+```ts
+// src/app/api/hello+api.ts
+export function GET() {
+  return Response.json({ hello: "world" });
+}
+```
 
 Create a router:
 

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "expo-trpc-starter",
     "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true
@@ -14,7 +14,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "predictiveBackGestureEnabled": false
     },
     "web": {
       "bundler": "metro",

--- a/scripts/reset-project.js
+++ b/scripts/reset-project.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+ * Reset the starter to a blank Expo Router app.
+ *
+ * The script can move the current src directory to /example/src before creating
+ * a fresh src/app/index.tsx and src/app/_layout.tsx. It is intentionally
+ * interactive because it can remove application code.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline");
+
+const root = process.cwd();
+const exampleDir = "example";
+const oldDirs = ["src"];
+const newAppDir = "src/app";
+const exampleDirPath = path.join(root, exampleDir);
+
+const indexContent = `import { StyleSheet, Text, View } from "react-native";
+
+export default function Index() {
+  return (
+    <View style={styles.container}>
+      <Text>Edit src/app/index.tsx to edit this screen.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+`;
+
+const layoutContent = `import { Stack } from "expo-router";
+
+export default function RootLayout() {
+  return <Stack />;
+}
+`;
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+async function moveOrDeleteDirectories(userInput) {
+  try {
+    if (userInput === "y") {
+      await fs.promises.mkdir(exampleDirPath, { recursive: true });
+      console.log(`Created /${exampleDir}.`);
+    }
+
+    for (const dir of oldDirs) {
+      const oldDirPath = path.join(root, dir);
+
+      if (!fs.existsSync(oldDirPath)) {
+        console.log(`/${dir} does not exist, skipping.`);
+        continue;
+      }
+
+      if (userInput === "y") {
+        const newDirPath = path.join(root, exampleDir, dir);
+        await fs.promises.rm(newDirPath, { recursive: true, force: true });
+        await fs.promises.rename(oldDirPath, newDirPath);
+        console.log(`Moved /${dir} to /${exampleDir}/${dir}.`);
+      } else {
+        await fs.promises.rm(oldDirPath, { recursive: true, force: true });
+        console.log(`Deleted /${dir}.`);
+      }
+    }
+
+    const newAppDirPath = path.join(root, newAppDir);
+    await fs.promises.mkdir(newAppDirPath, { recursive: true });
+    await fs.promises.writeFile(path.join(newAppDirPath, "index.tsx"), indexContent);
+    await fs.promises.writeFile(path.join(newAppDirPath, "_layout.tsx"), layoutContent);
+
+    console.log("\nProject reset complete.");
+    console.log("Next steps:");
+    console.log("1. Run `bun run start`.");
+    console.log("2. Edit `src/app/index.tsx`.");
+    console.log("3. Keep route files in `src/app` and shared app code outside it.");
+  } catch (error) {
+    console.error(`Error during reset: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+rl.question(
+  "Move existing src to /example before creating a blank app? (Y/n): ",
+  (answer) => {
+    const userInput = answer.trim().toLowerCase() || "y";
+
+    if (userInput !== "y" && userInput !== "n") {
+      console.log("Invalid input. Please enter Y or n.");
+      rl.close();
+      process.exitCode = 1;
+      return;
+    }
+
+    moveOrDeleteDirectories(userInput).finally(() => rl.close());
+  }
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
 
     /* Path Aliases */
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/assets/*": ["./assets/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

Aligns the starter with the current structure generated by `create-expo-app` while preserving the tRPC/API Routes behavior this template needs.

I created a fresh temporary Expo project, compared the generated files, then deleted the temporary project. The current Expo template uses `src/app`, so this PR keeps that layout and documents why this starter differs from the default web output: API Routes require `web.output` to stay on `server`.

## Changes

- Adds the missing `scripts/reset-project.js` script referenced by `package.json`, adapted for the `src/app` Expo Router layout.
- Documents the verified `src/app` structure and the minimal `hello+api.ts` API route example in the README.
- Adds the `@/assets/*` TypeScript path alias from the current Expo template.
- Updates app config with a project-specific scheme and Android `predictiveBackGestureEnabled` setting.
- Updates `.gitignore` for generated native folders and reset-script examples.
- Notes the alignment work in the changelog.

## Validation

- `node --check scripts/reset-project.js`
- `bun run typecheck`
- `bun run lint`
- `bunx expo-doctor`

## Notes

The temporary Expo project used for comparison was deleted after inspection. The reset script was syntax-checked but not executed because it intentionally moves or deletes app code.
